### PR TITLE
Files displayed should be governed by max_files, not max_height

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -302,7 +302,7 @@ fu! s:Update(pat, ...)
 	if notail == oldstr && !empty(notail) && !exists('a:1') && !exists('s:force')
 		retu
 	en
-	let lines = s:MatchedItems(g:ctrlp_lines, pats, s:mxheight)
+	let lines = s:MatchedItems(g:ctrlp_lines, pats, s:maxfiles)
 	cal s:Render(lines, pats[-1])
 endf
 


### PR DESCRIPTION
This changes the list of files returned by a search to be limited by max_files, but keeps the viewable area limited by max_height. The default behavior doesn't allow you to scroll to see more matching files, this changes that.
