### PR TITLE
Migemo Search

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -235,6 +235,18 @@ endf
 "}}}
 fu! s:SplitPattern(str, ...) "{{{
 	let str = s:sanstail(a:str)
+	if len(str) > 0 && exists('g:ctrlp_use_migemo') && executable('cmigemo')
+		let dict = globpath(&rtp, printf("dict/%s/migemo-dict", &encoding))
+		if len(dict) == 0
+			let dict = globpath(&rtp, "dict/migemo-dict")
+		en
+		if len(dict)
+			let ret = system(printf('cmigemo -v -w %s -d %s', shellescape(str), shellescape(dict)))
+			if v:shell_error == 0 && len(ret) > 0
+				let str = ret
+			en
+		en
+	en
 	let s:savestr = str
 	if s:regexp || match(str, '\\\(zs\|ze\|<\|>\)\|[*|]') >= 0
 		let array = [s:regexfilter(str)]


### PR DESCRIPTION
Hi.
Thanks for your awesome plugin.

For japanese, we have a lot of files that named in japanese. So we can't use ctrlp.vim to search the files.
For example, we can write `aiueo` in few expression like below.
- `aiueo` in roman
- `あいうえお` in japanese hiragana
- `アイウエオ` in japanese katakana

And we also use KANJI. KANJI is composed by few symbols.

Then, I think that `migemo` is good to solve the problem. `migemo` can convert string to possible regular expression.
For example, `migemo` can convert `aiueo` to following.

```
\%(ｱ\_s*ｲ\_s*ｳ\_s*ｴ\_s*ｵ\|ア\_s*イ\_s*ウ\_s*エ\_s*オ\|あ\_s*い\_s*う\_s*え\_s*お\|ａ\_s*ｉ\_s*ｕ\_s*ｅ\_s*ｏ\|a\_s*i\_s*u\_s*e\_s*o\)
```

For about KANJI, `nihon` (is meaning `japan` in japanese) is:

```
\%(∥\|二\_s*本\|ﾆ\_s*ﾎ\_s*[ﾝﾉﾈﾇﾆﾅ]\|に\_s*ほ\_s*[んのねぬにな]\|ｎ\_s*ｉ\_s*ｈ\_s*ｏ\_s*ｎ\|日\_s*本\|ニ\_s*ホ\_s*[ノネヌニナン]\|n\_s*i\_s*h\_s*o\_s*n\)
```

I added bits change to use `migemo`. And ctrlp.vim become VERY useful for me.
If you arrow this change, please include this.

If you can't show japanese above, please see the image.

http://go-gyazo.appspot.com/9921943e31b728ed.png

Thanks.
