### PR TITLE
Fix migemo

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -238,7 +238,7 @@ endf
 "}}}
 fu! s:SplitPattern(str, ...) "{{{
 	let str = s:sanstail(a:str)
-	if s:migemo && len(str) > 0 && executable('cmigemo')
+	if s:regexp && s:migemo && len(str) > 0 && executable('cmigemo')
 		let dict = s:glbpath(&rtp, printf("dict/%s/migemo-dict", &encoding), 1)
 		if !len(dict)
 			let dict = s:glbpath(&rtp, "dict/migemo-dict", 1)

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -297,7 +297,8 @@ If is 1, update after 250ms. If bigger than 1, the number will be used as the
 delay time in milliseconds.
 
                                                          *'g:ctrlp_use_migemo'*
-Set this to 1 to use Migemo for Japanese filenames: >
+Set this to 1 to use Migemo Pattern for Japanese filenames. Migemo Search
+works in |regexp| mode. To split the pattern, separate words with space: >
   let g:ctrlp_use_migemo = 0
 <
 


### PR DESCRIPTION
When using Migemo, it can't match to wild pattern.
For example,

```
test1/XXXX.txt
test2/XXXXfoo.txt
test2/XXXXbar.txt
```

XXXX is multi-byte words. And YYYY is source to match XXXX that user will types.
Currently, ctrlp is treating the input string as whole string for migemo parameter, so we can't match files below in once.

```
test2/XXXXfoo.txt
test2/XXXXbar.txt
----------------------------
>>> test2
-------------- can't continue the pattern to match XXXX
```

```
test1/XXXXX.txt
test2/XXXXfoo.txt
test2/XXXXbar.txt
----------------------------
>>> YYYY
-------------- match with migemo, but can't include pattern for testX.
```

Then, I added bits change.

```
test2/XXXXfoo.txt
----------------------------
>>> test YYYY foo
-------------- nice! :)
```

And I added check wheter s:regexp is set or not for migemo.
Then, we can switch the modes with CTRL+R.

Thanks.
