### PR TITLE
Added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
When generating the helptags, /doc/tags is created, which isn't tracked.
