### PR TITLE
enable jump-to-open-buffer feature when trying to open buffer in tab

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -669,7 +669,7 @@ fu! ctrlp#acceptfile(mode, matchstr, ...)
 	let filpath = s:itemtype ? matchstr : getcwd().s:lash.matchstr
 	cal s:PrtExit()
 	let bufnum = bufnr(filpath)
-	if s:jmptobuf && bufnum > 0 && md == 'e'
+	if s:jmptobuf && bufnum > 0 && (md == 'e' || md == 't')
 		let [jmpb, bufwinnr] = [1, bufwinnr(bufnum)]
 		let buftab = s:jmptobuf > 1 ? s:buftab(bufnum) : [0, 0]
 		let j2l = a:0 ? a:1 : str2nr(matchstr(s:tail(), '^ +\zs\d\+$'))


### PR DESCRIPTION
The 'jump-to-open-buffer' feature works only with <cr>. It should work with <c-t> same as <cr>.
