### PR TITLE
Make arrow keys work with TERM=linux

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -600,7 +600,7 @@ fu! s:MapSpecs(...)
 	en
 	" Correct arrow keys in terminal
 	if ( has('termresponse') && !empty(v:termresponse) )
-		\ || &term =~? 'xterm\|\<k\?vt\|gnome\|screen'
+		\ || &term =~? 'xterm\|\<k\?vt\|gnome\|screen\|linux'
 		for each in ['\A <up>','\B <down>','\C <right>','\D <left>']
 			exe lcmap.' <esc>['.each
 		endfo


### PR DESCRIPTION
Hello,

This pull request fixes a problem when using ctrlp.vim with a Linux TTY.

E.g. when the TERM variable is set to "linux", the arrow keys don't work.

My patch solves this. Please accept it.

Thanks,

Diego
