### PR TITLE
call CreateNewFile() when there is no match entry

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -741,6 +741,12 @@ endf
 fu! s:AcceptSelection(mode)
 	if a:mode == 'e' | if s:SpecInputs() | retu | en | en
 	" Get the selected line
+	let line = getline('.')
+	if line == ' == NO ENTRIES =='
+		cal <SID>CreateNewFile()
+		retu
+	en
+	let matchstr = matchstr(line, '^> \zs.\+\ze\t*$')
 	let matchstr = matchstr(getline('.'), '^> \zs.\+\ze\t*$')
 	if empty(matchstr) | retu | en
 	" Do something with it


### PR DESCRIPTION
With this patch, if there is no matching entry, create and open a new file by hitting `<Enter>` (`<C-t>`, `<C-v>`, `<C-Enter>` and so on) like `<C-y>`.
