### PR TITLE
Change default cache directory to ~/.cache/ctrlp

### DIFF
--- a/autoload/ctrlp/utils.vim
+++ b/autoload/ctrlp/utils.vim
@@ -15,9 +15,16 @@ fu! s:lash(...)
 endf
 
 fu! ctrlp#utils#opts()
-	let s:cache_dir = $HOME.s:lash($HOME).'.ctrlp_cache'
+	let cache_home = exists('$XDG_CACHE_HOME') ? $XDG_CACHE_HOME : $HOME.'/.cache'
+	let s:cache_dir = cache_home.'/ctrlp'
+	" Support old default, for compatibility
+	if !isdirectory(s:cache_dir) && isdirectory($HOME.s:lash($HOME).'.ctrlp_cache')
+		let s:cache_dir = $HOME.s:lash($HOME).'.ctrlp_cache'
+	en
+	" User option
 	if exists('g:ctrlp_cache_dir')
 		let s:cache_dir = expand(g:ctrlp_cache_dir, 1)
+		" Support old suffix
 		if isdirectory(s:cache_dir.s:lash(s:cache_dir).'.ctrlp_cache')
 			let s:cache_dir = s:cache_dir.s:lash(s:cache_dir).'.ctrlp_cache'
 		en

--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -123,7 +123,7 @@ upon exiting Vim: >
 
                                                           *'g:ctrlp_cache_dir'*
 Set the directory to store the cache files: >
-  let g:ctrlp_cache_dir = $HOME.'/.ctrlp_cache'
+  let g:ctrlp_cache_dir = $HOME.'/.cache/ctrlp'
 <
 
                                                     *'g:ctrlp_prompt_mappings'*


### PR DESCRIPTION
As per http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

This change is backward compatible: if `~/.cache/ctrlp` doesn't exist but `~/.ctrlp_cache` does, the latter will still be used.
