### PR TITLE
Fix cannot go to the other buffer problem

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1363,8 +1363,9 @@ fu! s:openfile(cmd, filpath, ...)
 	let cmd = a:cmd =~ '^[eb]$' && &modified ? 'hid '.a:cmd : a:cmd
 	let cmd = cmd =~ '^tab' ? tabpagenr('$').cmd : cmd
 	let tail = a:0 ? a:1 : s:tail()
-	exe cmd.tail.' '.ctrlp#fnesc(a:filpath)
+	exe cmd.' '.ctrlp#fnesc(a:filpath)
 	if !empty(tail)
+		call cursor(str2nr(tail), 1)
 		sil! norm! zvzz
 	en
 	if exists('*haslocaldir')


### PR DESCRIPTION
Hi Kien,

Thank you for the nice plugin ctrlp.vim.

I encountered an error when I was using Line extension, please see following:

a.txt:

```
foo bar baz
```

b.txt:

```
hoge fuga moge
```

---

```
% vim a.txt b.txt
:CtrlPLine
>>> hoge<Return>

Error detected while processing function <SNR>52_AcceptSelection..ctrlp#line#accept..ctrlp#acceptfile..<SNR>52
_openfile:
line    4:
E94: No matching buffer for +1 2
```

I can see same error when I press &lt;C-x&gt;, &lt;C-v&gt; and &lt;C-t&gt; as well.
Probably, `:buffer`, `:sbuffer` and `:tab` do not accept `+{lnum}`.

I worry about that `tail`, local variable of  `s:openfile` (`autoload/ctrlp.vim`), whether can be always converted to a number.

Thanks:)
