### PR TITLE
Rename commands that weren't prefixed with CtrlP

### DIFF
--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -407,18 +407,18 @@ COMMANDS                                                       *ctrlp-commands*
 :CtrlPMRU
    Open |CtrlP| in find Most-Recently-Used file mode.
 
-                                                             *:ClearCtrlPCache*
-:ClearCtrlPCache
+                                                             *:CtrlPClearCache*
+:CtrlPClearCache
    Flush the cache for the current working directory. The same as pressing <F5>
    inside |CtrlP|.
    You can also enable/disable caching with the option |g:ctrlp_use_caching|.
 
-                                                         *:ClearAllCtrlPCaches*
-:ClearAllCtrlPCaches
+                                                         *:CtrlPClearAllCaches*
+:CtrlPClearAllCaches
    Delete all the cache files saved in |g:ctrlp_cache_dir|.
 
-                                                                  *:ResetCtrlP*
-:ResetCtrlP
+                                                                  *:CtrlPReset*
+:CtrlPReset
    Reset all options and take in new values of the option variables.
 
 -------------------------------------------------------------------------------

--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -18,9 +18,9 @@ com! -n=? -com=dir CtrlP cal ctrlp#init(0, <q-args>)
 com! CtrlPBuffer   cal ctrlp#init(1)
 com! CtrlPMRUFiles cal ctrlp#init(2)
 
-com! ClearCtrlPCache     cal ctrlp#clr()
-com! ClearAllCtrlPCaches cal ctrlp#clra()
-com! ResetCtrlP          cal ctrlp#reset()
+com! CtrlPClearCache     cal ctrlp#clr()
+com! CtrlPClearAllCaches cal ctrlp#clra()
+com! CtrlPReset          cal ctrlp#reset()
 
 com! CtrlPCurWD   cal ctrlp#init(0, 0)
 com! CtrlPCurFile cal ctrlp#init(0, 1)


### PR DESCRIPTION
I renamed the commands weren't prefixed with Ctrp for consistency with the other commands. I updated the docs accordingly.

It's has been very difficult to find the clear commands because of the fact they don't follow the prefixed convention. I really hope it helps. 

The plugin is wonderful. Thank you for working on it.
