### PR TITLE
Allow empty tag files.

### DIFF
--- a/autoload/ctrlp/tag.vim
+++ b/autoload/ctrlp/tag.vim
@@ -42,6 +42,7 @@ endf
 fu! s:filter(tags)
 	let [nr, alltags] = [0, a:tags]
 	wh 0 < 1
+		if empty(alltags) | brea | en
 		if alltags[nr] =~ '^!' && alltags[nr] !~ '^!_TAG_'
 			let nr += 1
 			con


### PR DESCRIPTION
Fixed an issue that caused a large number of errors in the 'tag' plugin if a tagfile was empty (or simply contained no tags).
