### PR TITLE
expand F to selected file, and expand D to selected directory.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -569,12 +569,12 @@ fu! s:PrtInsert(...)
 	unl! s:hstgot
 	let s:act_add = 1
 	let s:prompt[0] .= type == 'w' ? s:crword
-		\ : type == 's' ? getreg('/')
-		\ : type == 'v' ? s:crvisual
-		\ : type == 'c' ? substitute(getreg('+'), '\n', '\\n', 'g')
-		\ : type == 'f' ? s:crgfile
-		\ : type == 'F' ? s:lines[line('.') - 1]
-		\ : type == 'D' ? fnamemodify(s:lines[line('.') - 1], ':h') : s:prompt[0]
+		\ : type ==# 's' ? getreg('/')
+		\ : type ==# 'v' ? s:crvisual
+		\ : type ==# 'c' ? substitute(getreg('+'), '\n', '\\n', 'g')
+		\ : type ==# 'f' ? s:crgfile
+		\ : type ==# 'F' ? s:lines[line('.') - 1]
+		\ : type ==# 'D' ? fnamemodify(s:lines[line('.') - 1], ':h') : s:prompt[0]
 	cal s:BuildPrompt(1)
 	unl s:act_add
 endf


### PR DESCRIPTION
I often want to create a file that is positioned with selected file. For example,

```
> foo/bar/baz.txt
 prt  path  <launcher>={ files }=<buf> <-> <mattn/.vim/bundle/ctrlp.vim
>>> _
```

When I'm on above, and I want to create `foo/bar/bazooo.txt`, I must type `foo/bar/bazoo.txt`. So I added two keyboard shortcut for `<c-\>`.
- `<c-\>F` expand to current selected file.

```
> foo/bar/baz.txt
 prt  path  <launcher>={ files }=<buf> <-> <mattn/.vim/bundle/ctrlp.vim
>>> foo/bar/baz.txt_
```
- `<c-\>D` expand to directory of current selected file.

```
> foo/bar/baz.txt
 prt  path  <launcher>={ files }=<buf> <-> <mattn/.vim/bundle/ctrlp.vim
>>> foo/bar_
```

Then I can do it with typing just '/bazooo.txt'.
If ctrlp have already this function or shortcut keys, please teach for me. :)
