### PR TITLE
Add choice for how to sharten paths that are too long

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -55,6 +55,7 @@ let [s:pref, s:opts, s:new_opts] = ['g:ctrlp_', {
 	\ 'buffer_func':           ['s:buffunc', {}],
 	\ 'by_filename':           ['s:byfname', 0],
 	\ 'custom_ignore':         ['s:usrign', s:ignore()],
+	\ 'custom_formatline':     ['s:usrfrmtline', 's:formatline'],
 	\ 'default_input':         ['s:deftxt', 0],
 	\ 'dont_split':            ['s:nosplit', 'netrw'],
 	\ 'dotfiles':              ['s:dotfiles', 1],
@@ -77,7 +78,6 @@ let [s:pref, s:opts, s:new_opts] = ['g:ctrlp_', {
 	\ 'regexp_search':         ['s:regexp', 0],
 	\ 'root_markers':          ['s:rmarkers', []],
 	\ 'split_window':          ['s:splitwin', 0],
-	\ 'shorten_path_method':   ['s:spmethod', 0],
 	\ 'status_func':           ['s:status', {}],
 	\ 'use_caching':           ['s:caching', 1],
 	\ 'use_migemo':            ['s:migemo', 0],
@@ -464,7 +464,8 @@ fu! s:Render(lines, pat)
 	en
 	if s:mwreverse | cal reverse(lines) | en
 	let s:lines = copy(lines)
-	cal map(lines, 's:formatline(v:val)')
+	let FormatFunc = function(s:usrfrmtline)
+	cal map(lines, 'FormatFunc(v:val, s:ispath, s:winw)')
 	cal setline(1, lines)
 	setl noma cul
 	exe 'keepj norm!' ( s:mwreverse ? 'G' : 'gg' ).'1|'
@@ -1169,20 +1170,9 @@ fu! ctrlp#progress(enum, ...)
 	redraws
 endf
 " Paths {{{2
-fu! s:formatline(str)
-	let newstr = ( exists("*MyPathFilter") ? MyPathFilter(a:str) : a:str )
-	let cond = s:ispath && ( s:winw - 4 ) < s:strwidth(newstr)
-	retu '> '. ( cond ? s:pathshorten(newstr) : newstr )
-endf
-
-fu! s:pathshorten(str)
-	if s:spmethod
-		retu ( exists("*MyPathShorten") ?
-			\ MyPathShorten(a:str,s:winw) :
-			\ '...' . a:str[-(s:winw - 7):] )
-	else
-		retu pathshorten(a:str)
-	endif
+fu! s:formatline(str, ispath, winw)
+	let cond = a:ispath && ( a:winw - 4 ) < s:strwidth(a:str)
+	retu '> '. ( cond ? pathshorten(a:str) : a:str )
 endf
 
 fu! s:dircompl(be, sd)


### PR DESCRIPTION
Hi,

I've added a simple choice for how long paths should be shortened. When the standard pathshorten is used, files that have the same name but different directories are more difficult to find, which in my case happens alot. I therefore added a simple choice to change the way to shorten a file name.

My simple way is to just change the first part of the path name to "...".

If you want things to be more polished before merging, I could perhaps try to add some more choices and update the documentation.
