### PR TITLE
Fix root detection for new-style git submodules

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -822,7 +822,7 @@ fu! s:SetWD(...)
 		cal ctrlp#setdir(s:crfpath)
 	en
 	if pathmode == 1 | retu | en
-	let markers = ['root.dir', '.git/', '.hg/', '.svn/', '.bzr/', '_darcs/']
+	let markers = ['root.dir', '.git', '.hg/', '.svn/', '.bzr/', '_darcs/']
 	if type(s:rmarkers) == 3 && !empty(s:rmarkers)
 		cal extend(markers, s:rmarkers, 0)
 	en


### PR DESCRIPTION
In very recent versions of git, the submodule structure has changed. The .git
directory has been moved into the .git of super repo, and the .git in the
submodule is just a file with a relative path to the actual .git directory in
the supermodule.

Since this change, ctrlp will only find the super repo when running s:SetWD().
ctrlp will try to cache and search in all of your submodules, which quickly
becomes a problem if your project has many submodules.

This fix removes the trailing slash from the '.git/' entry in the markers list
in s:SetWD(), which makes ctrlp find the new-style submodule file before the
super repo.
