### PR TITLE
Small correction to ctags output parsing

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -183,7 +183,7 @@ fu! s:process(fname, ftype)
 endf
 
 fu! s:parseline(line)
-	let eval = '\v^([^\t]+)\t(.+)\t\/\^(.+)\$\/\;\"\t(.+)\tline(no)?\:(\d+)'
+	let eval = '\v^([^\t]+)\t(.+)\t\/\^?(.+)\$?\/\;\"\t(.+)\tline(no)?\:(\d+)'
 	let vals = matchlist(a:line, eval)
 	if vals == [] | retu '' | en
 	let [bufnr, bufname] = [bufnr('^'.vals[2].'$'), fnamemodify(vals[2], ':p:t')]


### PR DESCRIPTION
I wanted to use [CoffeeTags](https://github.com/lukaszkorecki/CoffeeTags) to get ctags support for my CoffeeScripts, but after adding the code below to my _.vimrc_ the CtrlPBufTag command only showed `== NO ENTRIES ==` in my _.coffee_ files.

``` viml
let g:ctrlp_buftag_types = {
  \ 'coffee' : {
    \ 'bin': 'coffeetags',
    \ 'args': '-f -',
    \ },
  \ }
```

I looked at the output of `coffeetags` and it surely generated what looked like a correct ctags format.

After some snooping around in the Ctrl-P code I found the ctags line parsing function and looked into the regex. Finding that the regex required that the pattern part of the ctags output starts with a circumflex and ends with a dollar sign. In the case of `coffeetags`, it doesn't use  the circumflex and dollar sign.

I also found this [spec. for the ctags output format](http://pubs.opengroup.org/onlinepubs/009695399/utilities/ctags.html#tag_04_30_12) which specifically states that the circumflex and dollar sign are optional.

Sure enough after editing the regex every thing worked perfectly.

Hope this patch helps and thanks for a brilliant VIM plugin! 
