### PR TITLE
readme.md: give mdfind example for OSX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@ Use `:diffthis` when opening multiple files to run `:diffthis` on the first 4 fi
 * Use a custom file listing command:
 
     ```vim
-    let g:ctrlp_user_command = 'find %s -type f'        " MacOSX/Linux
+    let g:ctrlp_user_command = 'mdfind -onlyin %s file' " MacOSX
+    let g:ctrlp_user_command = 'find %s -type f'        " Linux
     let g:ctrlp_user_command = 'dir %s /-n /b /s /a-d'  " Windows
     ```
 


### PR DESCRIPTION
mdfind on OSX uses spotlight in the background and is really fast even
on huge trees like the linux kernel. Suggest it in the docs.
