### PR TITLE
Make ctrlp#call to return results from methods

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2054,7 +2054,7 @@ fu! ctrlp#hicheck(grp, defgrp)
 endf
 
 fu! ctrlp#call(func, ...)
-	cal call(a:func, a:000)
+  return call(a:func, a:000)
 endf
 "}}}1
 " * Initialization {{{1


### PR DESCRIPTION
This is usefull to make extensions/custome match functions to executes
internal methods like MatchIt
