### PR TITLE
A new command to remove non-existing entries from the MRU cache file

### DIFF
--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -113,6 +113,23 @@ fu! ctrlp#mrufiles#cachefile()
 	retu s:cafile
 endf
 
+fu! ctrlp#mrufiles#cleancachefile()
+  echom 'Cleaning CtrlP MRU Cache list ...'
+
+  let cafile = ctrlp#mrufiles#cachefile()
+  let diskmrufs = ctrlp#utils#readfile(cafile)
+  let len = len(diskmrufs)
+
+  let diskmrufs = filter(diskmrufs, 'filereadable(v:val)')
+
+  if len(diskmrufs) < len
+    cal writefile(diskmrufs, cafile)
+    echom printf('[INFO] %d -> %d done!', len, len(diskmrufs))
+  el
+    echom '[INFO] No entries were removed from the cache file.'
+  en
+endf
+
 fu! ctrlp#mrufiles#init()
 	if !has('autocmd') | retu | en
 	let s:locked = 0

--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -66,4 +66,7 @@ com! -bar CtrlPBookmarkDir cal ctrlp#init(ctrlp#bookmarkdir#id())
 com! -n=? -com=custom,ctrlp#utils#dircompl CtrlPBookmarkDirAdd
 	\ cal ctrlp#call('ctrlp#bookmarkdir#add', <q-args>)
 
+com! -n=0 CtrlPCleanMRUCache
+  \ cal ctrlp#mrufiles#cleancachefile()
+
 " vim:ts=2:sw=2:sts=2


### PR DESCRIPTION
Hi Kien,

There are several non-existing file entries in the MRU cache file and its are rubbish.
I'd like to keep clean MRU cache file, so I implemented it as a command 'CtrlPCleanMRUCache'.
What do you think about this feature? aim, command name and coding standard etc...

Cheers,
Takahiro
