### PR TITLE
Tell Ctags to treat Clojure files as Lisp

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -49,6 +49,7 @@ let s:types = {
 	\ 'awk'    : '%sawk%sawk%sf',
 	\ 'beta'   : '%sbeta%sbeta%sfsv',
 	\ 'c'      : '%sc%sc%sdgsutvf',
+	\ 'clojure': '%slisp%slisp%sf',
 	\ 'cpp'    : '%sc++%sc++%snvdtcgsuf',
 	\ 'cs'     : '%sc#%sc#%sdtncEgsipm',
 	\ 'cobol'  : '%scobol%scobol%sdfgpPs',


### PR DESCRIPTION
Tell Ctags to treat Clojure as Lisp so I can use `CtrlPBufTag` and `CtrlPBufTagAll` in Clojure files.
