### PR TITLE
Center the screen on the tag after jumping.

### DIFF
--- a/autoload/ctrlp/tag.vim
+++ b/autoload/ctrlp/tag.vim
@@ -108,6 +108,7 @@ fu! ctrlp#tag#accept(mode, str)
 	el
 		exe cmd tg
 	en
+	sil! norm! zvzz
 	cal ctrlp#setlcdir()
 endf
 


### PR DESCRIPTION
This also makes the behavior consistent with buffertag, changes, and
quickfix.
