### PR TITLE
.p4config root markers are useful to have

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -893,7 +893,7 @@ fu! s:SetWD(args)
 		cal ctrlp#setdir(s:crfpath)
 	en
 	if pmode =~ 'r' || pmode == 2
-		let markers = ['.git', '.hg', '.svn', '.bzr', '_darcs']
+		let markers = ['.git', '.hg', '.svn', '.bzr', '_darcs', '.p4config']
 		let spath = pmode =~ 'd' ? s:dyncwd : pmode =~ 'w' ? s:cwd : s:crfpath
 		if type(s:rmarkers) == 3 && !empty(s:rmarkers)
 			if s:findroot(spath, s:rmarkers, 0, 0) != [] | retu | en


### PR DESCRIPTION
Looks like g:ctrlp_root_markers allows to add high priority root markers, but it doesn't work well if ctrlp is used from a path where somewhere up from current working directory both regular and high priority markers exist. Perforce (p4) is a bit of a special case, ~/.p4config is expected to be present for accessing p4 even without clients with source code.  And adding .p4config to g:ctrlp_root_markers will make ~/ root even when ctrlp is used from a git repo somewhere within one's home directory.  This simple fix should address the issue.
