### PR TITLE
Create CtrlPFallback to use fallback always

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -395,7 +395,7 @@ fu! s:lsCmd()
 		retu cmd[1]
 	elsei type(cmd) == 4 && ( has_key(cmd, 'types') || has_key(cmd, 'fallback') )
 		let fndroot = []
-		if has_key(cmd, 'types') && cmd['types'] != {}
+		if !s:shouldUseFallback && has_key(cmd, 'types') && cmd['types'] != {}
 			let [markrs, cmdtypes] = [[], values(cmd['types'])]
 			for pair in cmdtypes
 				cal add(markrs, pair[0])
@@ -1198,6 +1198,10 @@ fu! s:OpenNoMarks(md, line)
 		en
 	en
 endf
+
+fu! s:UseFallback(opts)
+	let s:shouldUseFallback = get(a:opts, 'fallback', 0)
+endfu
 " ** Helper functions {{{1
 " Sorting {{{2
 fu! ctrlp#complen(...)
@@ -2151,6 +2155,7 @@ fu! ctrlp#init(type, ...)
 	let [s:ermsg, v:errmsg] = [v:errmsg, '']
 	let [s:matches, s:init] = [1, 1]
 	cal s:Reset(a:0 ? a:1 : {})
+	cal s:UseFallback(a:0 ? a:1 : {})
 	noa cal s:Open()
 	cal s:SetWD(a:0 ? a:1 : {})
 	cal s:MapNorms()

--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -33,6 +33,9 @@ com! -bar CtrlPCurWD   cal ctrlp#init(0, { 'mode': '' })
 com! -bar CtrlPCurFile cal ctrlp#init(0, { 'mode': 'c' })
 com! -bar CtrlPRoot    cal ctrlp#init(0, { 'mode': 'r' })
 
+com! -n=? -com=custom,ctrlp#utils#dircompl CtrlPFallback
+	\ cal ctrlp#init(0, { 'dir': <q-args>, 'fallback': 1})
+
 if g:ctrlp_map != '' && !hasmapto(':<c-u>'.g:ctrlp_cmd.'<cr>', 'n')
 	exe 'nn <silent>' g:ctrlp_map ':<c-u>'.g:ctrlp_cmd.'<cr>'
 en


### PR DESCRIPTION
@kien, I use the following setup for ctrlp:

``` vim
let g:ctrlp_user_command = {
  \ 'types' : {
    \ 1: ['.git', 'cd %s && git ls-tree -r HEAD | grep -v -e "^\d\+\scommit" | cut -f 2']
    \ },
  \ 'fallback': 'find %s -type f'
  \ }
```

The git command will grab the files in the repo, excluding submodules. It has improved the speed for large trees greatly.
The problem is that new files which haven't been commited yet to the repo will not show up in Ctrlp's list anymore. That is a little annoying when new files are being added to the repo.

I tried looking for some other solutions using the commands already available in Ctrlp, but couldn't really grasp any, so I created `:CtrlPFallback` command to always call the fallback method, which will show any new files in the repo.

If you have any concerns about this approach, you can direct me and I'll continue to work on it.
Thanks
