### PR TITLE
Default to CtrlPMixed

### DIFF
--- a/plugin/ctrlp.vim
+++ b/plugin/ctrlp.vim
@@ -15,7 +15,7 @@ let [g:ctrlp_lines, g:ctrlp_allfiles, g:ctrlp_alltags, g:ctrlp_alldirs,
 	\ = [[], [], [], [], {}, {}, [], 2]
 
 if !exists('g:ctrlp_map') | let g:ctrlp_map = '<c-p>' | en
-if !exists('g:ctrlp_cmd') | let g:ctrlp_cmd = 'CtrlP' | en
+if !exists('g:ctrlp_cmd') | let g:ctrlp_cmd = 'CtrlPMixed' | en
 
 com! -n=? -com=dir CtrlP         cal ctrlp#init(0, { 'dir': <q-args> })
 com! -n=? -com=dir CtrlPMRUFiles cal ctrlp#init(2, { 'dir': <q-args> })


### PR DESCRIPTION
Without reading the documentation, it's not obvious that CtrlP has three modes. Even knowing that there were modes, I did not learn how to switch between them until I stumbled upon it accidentally after about a month. I only now realized that there was a mixed mode, which is really _exactly what I want_. 

Mixed mode is similar to the behavior of TextMate and SublimeText, which is pretty intuitive. MRU and buffer files are very frequently reopened, which makes Mixed mode great.

With the occasional difficulty of finding some files because of #110, having Mixed mode on by default will at least allieve this issue after the first time the file is opened.

Is there any reason I'm not thinking of why Mixed mode should not be the default?
