### PR TITLE
Invoke vim function if g:ctrlp_user_command starts with '*'.

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -319,6 +319,10 @@ fu! ctrlp#files()
 			if !ctrlp#igncwd(s:dyncwd)
 				cal s:GlobPath(s:fnesc(s:dyncwd, 'g', ','), 0)
 			en
+    elsei lscmd[0] == '*'
+      if !ctrlp#igncwd(s:dyncwd)
+        let g:ctrlp_allfiles = call(lscmd[1:], [s:fnesc(s:dyncwd, 'g', ',')])
+      en
 		el
 			sil! cal ctrlp#progress('Indexing...')
 			try | cal s:UserCmd(lscmd)


### PR DESCRIPTION
Use user-defined vimscript function if `g:ctrlp_user_command` starts with '*'.

In windows, globapath() is very slow. So I want to use another function such as `if_python` interface.

[User function sample](https://gist.github.com/sgur/5806782)
This sample use if_python interface to glob files (and considering depth and ignoring patterns).

The function is almost x2 faster than `globpath()` in windows.
