### PR TITLE
Allow the public bookmark command to include a name for the bookmark,

### DIFF
--- a/autoload/ctrlp/bookmarkdir.vim
+++ b/autoload/ctrlp/bookmarkdir.vim
@@ -112,12 +112,14 @@ fu! ctrlp#bookmarkdir#accept(mode, str)
 	en
 endf
 
-fu! ctrlp#bookmarkdir#add(dir)
+fu! ctrlp#bookmarkdir#add(dir, ...)
 	let str = 'Directory to bookmark: '
 	let cwd = a:dir != '' ? a:dir : s:getinput(str, getcwd(), 'dir')
 	if cwd == '' | retu | en
 	let cwd = fnamemodify(cwd, ':p')
-	let name = s:getinput('Bookmark as: ', cwd)
+	" If we got an extra argument and it isn't an empty string,
+	" use it as bookmark dir name
+	let name = a:0 == 1 && a:1 != '' ? a:1 : s:getinput('Bookmark as: ', cwd)
 	if name == '' | retu | en
 	let name = tr(name, '	', ' ')
 	cal s:savebookmark(name, cwd)


### PR DESCRIPTION
Existing functionality is preserved. I'd like to automate creating a bunch of bookmarks and I couldn't find an existing way to do that.
