### PR TITLE
Avoid invalid expression and type mismatch

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1084,8 +1084,11 @@ fu! s:AcceptSelection(action)
 			let type = exttype == 'dict' ? exttype : 'list'
 		en
 	en
-	let actargs = type == 'dict' ? [{ 'action': md, 'line': line, 'icr': icr }]
-		\ : [md, line]
+	if type ==# 'dict'
+		let actargs = [{ 'action': md, 'line': line, 'icr': icr }]
+	el
+		let actargs = [md, line]
+	en
 	cal call(actfunc, actargs)
 endf
 " - CreateNewFile() {{{1


### PR DESCRIPTION
Invalid expression error is produced when trying to open certain tags: This avoids the error:

Error detected while processing function <SNR>57_AcceptSelection:
line   30:
E685: Internal error: get_tv_string_buf()
E15: Invalid expression: type == 'dict' ? [{ 'action': md, 'line': line, 'icr': icr }] : [md, line]
line   31:
E121: Undefined variable: actargs
E116: Invalid arguments for function call
