### PR TITLE
Allow to disable tail commands from an extension

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -1831,6 +1831,9 @@ fu! s:sanstail(str)
 		\ substitute(a:str, '^\(@.*$\|\\\\\ze@\|\.\.\zs[.\/]\+$\)', '', 'g') : a:str
 	let [str, pat] = [substitute(str, '\\\\', '\', 'g'), '\([^:]\|\\:\)*$']
 	unl! s:optail
+	if !s:getextvar('sanstail')
+		retu str
+	en
 	if str =~ '\\\@<!:'.pat
 		let s:optail = matchstr(str, '\\\@<!:\zs'.pat)
 		let str = substitute(str, '\\\@<!:'.pat, '', '')


### PR DESCRIPTION
Allow extensions that do not work on files or buffers (like 'undo', 'dir', etc), to disable tail command parsing. More precisely, disable this behaviour:

```
End the string with a colon ':' followed by a Vim command to execute that
command after opening the file. If you need to use ':' literally, escape it
with a backslash: '\:'.
```

The extension will have to:

``` vim
call add(g:ctrlp_ext_vars, {'sanstail': 0})
```
