### PR TITLE
add ability mapping to mark all files

### DIFF
--- a/doc/ctrlp.txt
+++ b/doc/ctrlp.txt
@@ -538,9 +538,10 @@ only need to keep the lines that you've changed the values (inside []): >
     \ 'PrtClearCache()':      ['<F5>'],
     \ 'PrtDeleteEnt()':       ['<F7>'],
     \ 'CreateNewFile()':      ['<c-y>'],
-    \ 'MarkToOpen()':         ['<c-z>'],
+    \ 'MarkToOpen(0)':        ['<c-z>'],
+    \ 'MarkToOpen(1)':        ['<c-g>'],
     \ 'OpenMulti()':          ['<c-o>'],
-    \ 'PrtExit()':            ['<esc>', '<c-c>', '<c-g>'],
+    \ 'PrtExit()':            ['<esc>', '<c-c>'],
     \ }
 <
 Note: if pressing <bs> moves the cursor one character to the left instead of


### PR DESCRIPTION
This adds the ability to mark all files instead of just a single file.  I'm not so sure about the mapping - I didn't find any appropriate key binding that would work / was free.
