### PR TITLE
Tab drilling

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -712,6 +712,12 @@ fu! s:PrtExpandDir()
 			let str = fnamemodify(s:fnesc(spc, 'g'), mdr).nmd
 		en
 	en
+	if str == ''
+		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
+		if len(dir) == 2
+			let str = dir[0]
+		en
+	en
 	if str == '' | retu | en
 	unl! s:hstgot
 	let s:act_add = 1
@@ -724,6 +730,20 @@ fu! s:PrtExpandDir()
 		let str = dirs[0]
 	elsei len(dirs) > 1
 		let str .= s:findcommon(dirs, str)
+	el
+		let slash = s:lash()
+		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
+		if len(dir) == 2
+			while str[:len(dir[0])] == dir[0]
+				let tmp = s:headntail(dir[1], 'g'))
+				if len(tmp) == 2
+					let dir = [dir[0].slash.tmp[0], tmp[1]]
+				el
+					break
+				en
+			endw
+			let str = dir[0].slash
+		en
 	en
 	let s:prompt[0] = exists('hasat') ? hasat[0].str : str
 	cal s:BuildPrompt(1)

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -712,11 +712,12 @@ fu! s:PrtExpandDir()
 			let str = fnamemodify(s:fnesc(spc, 'g'), mdr).nmd
 		en
 	en
+	let str_tmp = str
 	if str == ''
-		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
-		if len(dir) == 2 && dir[0] != ''
-			let str = dir[0].s:lash()
-		en
+		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
+		 if len(dir) == 2 && dir[0] != ''
+			  let str = dir[0].s:lash()
+		 en
 	en
 	if str == '' | retu | en
 	unl! s:hstgot
@@ -730,20 +731,25 @@ fu! s:PrtExpandDir()
 		let str = dirs[0]
 	elsei len(dirs) > 1
 		let str .= s:findcommon(dirs, str)
-	el
-		let slash = s:lash()
-		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
-		if len(dir) == 2 && dir[0] != ''
-			while str[:len(dir[0])] == dir[0]
-				let tmp = s:headntail(dir[1], 'g'))
-				if len(tmp) == 2 && dir[0] != ''
-					let dir = [dir[0].slash.tmp[0], tmp[1]]
-				el
-					break
-				en
-			endw
-			let str = dir[0].slash
-		en
+	en
+	if str_tmp == str
+		 let slash = s:lash()
+		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
+		 if len(dir) == 2 && dir[0] != ''
+			  let exp = 1
+			  while exp
+				   if str[:len(dir[0])] != dir[0]
+					    let exp = 0
+				   en
+				   let tmp = s:headfirstntail(dir[1])
+				   if len(tmp) == 2 && dir[0] != ''
+					    let dir = [dir[0].slash.tmp[0], tmp[1]]
+				   el
+					    break
+				   en
+			  endw
+			  let str = dir[0].slash
+		 en
 	en
 	let s:prompt[0] = exists('hasat') ? hasat[0].str : str
 	cal s:BuildPrompt(1)
@@ -1510,6 +1516,13 @@ endf
 " Misc {{{3
 fu! s:headntail(str)
 	let parts = split(a:str, '[\/]\ze[^\/]\+[\/:]\?$')
+	retu len(parts) == 1 ? ['', parts[0]] : len(parts) == 2 ? parts : []
+endf
+
+fu! s:headfirstntail(str)
+	" seems to be a bug in vim
+	" let parts = split(a:str, '^[^\/]\+\zs[\/]')
+	let parts = matchlist(a:str, '^\([^\/]\+\)\zs[\/]\(.*\)$')[1:2]
 	retu len(parts) == 1 ? ['', parts[0]] : len(parts) == 2 ? parts : []
 endf
 

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -714,8 +714,8 @@ fu! s:PrtExpandDir()
 	en
 	if str == ''
 		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
-		if len(dir) == 2
-			let str = dir[0]
+		if len(dir) == 2 && dir[0] != ''
+			let str = dir[0].s:lash()
 		en
 	en
 	if str == '' | retu | en
@@ -733,10 +733,10 @@ fu! s:PrtExpandDir()
 	el
 		let slash = s:lash()
 		let dir = s:headntail(s:fnesc(ctrlp#getcline(), 'g'))
-		if len(dir) == 2
+		if len(dir) == 2 && dir[0] != ''
 			while str[:len(dir[0])] == dir[0]
 				let tmp = s:headntail(dir[1], 'g'))
-				if len(tmp) == 2
+				if len(tmp) == 2 && dir[0] != ''
 					let dir = [dir[0].slash.tmp[0], tmp[1]]
 				el
 					break

--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -715,8 +715,12 @@ fu! s:PrtExpandDir()
 	let str_tmp = str
 	if str == ''
 		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
-		 if len(dir) == 2 && dir[0] != ''
-			  let str = dir[0].s:lash()
+		 if len(dir) == 2 && dir[0] != '' && isdirectory(dir[0])
+				cal ctrlp#setdir(dir[0])
+				cal ctrlp#switchtype(0)
+				cal ctrlp#recordhist()
+				cal s:PrtClear()
+				return
 		 en
 	en
 	if str == '' | retu | en
@@ -735,7 +739,7 @@ fu! s:PrtExpandDir()
 	if str_tmp == str
 		 let slash = s:lash()
 		 let dir = s:headfirstntail(s:fnesc(ctrlp#getcline(), 'g'))
-		 if len(dir) == 2 && dir[0] != ''
+		 if len(dir) == 2 && dir[0] != '' && isdirectory(dir[0])
 			  let exp = 1
 			  while exp
 				   if str[:len(dir[0])] != dir[0]
@@ -748,7 +752,11 @@ fu! s:PrtExpandDir()
 					    break
 				   en
 			  endw
-			  let str = dir[0].slash
+				cal ctrlp#setdir(dir[0])
+				cal ctrlp#switchtype(0)
+				cal ctrlp#recordhist()
+				cal s:PrtClear()
+				return
 		 en
 	en
 	let s:prompt[0] = exists('hasat') ? hasat[0].str : str


### PR DESCRIPTION
This patch adds additional abilities to the tab key to expand directories based on the currently selected entry.
1. If the user didn't type anything, tab now expands the directory name of the selected entry.  Before it didn't do anything
2. If the user typed something, tab now expands the directory one after the other while maintaining any other expansion that happened before
