### PR TITLE
Make README screenshot narrower to fit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,6 @@ Check `:help ctrlp-options` for other options.
 ## Installation
 Use your favorite method or check the homepage for a [quick installation guide][3].
 
-[1]: http://i.imgur.com/yIynr.png
+[1]: http://i.imgur.com/aOcwHwt.png
 [2]: https://github.com/kien/ctrlp.vim/tree/extensions
 [3]: http://kien.github.com/ctrlp.vim#installation


### PR DESCRIPTION
Make README screenshot narrower so it fits on the GitHub project home page

The current screenshot as displayed on https://github.com/kien/ctrlp.vim is squished to fit within 722px, introducing aliasing and making the screenshot hard to read. This updated image is 720px, so it will fit without having to be resized, and provide a better first impression of ctrlp.vim to people visiting the project page.

You can see what the screenshot looks like on [this patch’s GitHub page](https://github.com/roryokane/ctrlp.vim/tree/patch-1), compared to [the current project home page](https://github.com/kien/ctrlp.vim).

I produced this screenshot in Photoshop by effectively deleting some of the empty space in the middle. The window in the image might not be a realistically-sized one – its width might not be a multiple of the character cell width – but nobody will notice.
