### PR TITLE
Added CtrlPMark highlight group

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -283,7 +283,12 @@ fu! s:Open()
 		sil! exe 'let s:glb_'.ke.' = &'.ke.' | let &'.ke.' = '.string(va)
 	en | endfo
 	if s:opmul != '0' && has('signs')
-		sign define ctrlpmark text=+> texthl=Search
+		sign define ctrlpmark text=+> texthl=CtrlPMark
+		if version < 508
+			hi link CtrlPMark Search
+		else
+			hi def link CtrlPMark Search
+		endif
 	en
 	cal s:setupblank()
 endf


### PR DESCRIPTION
This creates the ability to add custom highlighting to CtrlP signs/marks
if someone wishes to change them. It links back to the Search group to
maintain backwards compatibility.
