### PR TITLE
Add function ctrlp#clearmarkedlist()

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -2206,6 +2206,10 @@ fu! ctrlp#getmarkedlist()
 	retu exists('s:marked') ? values(s:marked) : []
 endf
 
+fu! ctrlp#clearmarkedlist()
+  let s:marked = {}
+endf
+
 fu! ctrlp#exit()
 	cal s:PrtExit()
 endf


### PR DESCRIPTION
I have [a plugin](https://github.com/d11wtq/ctrlp_bdelete.vim) that integrates with ctrlp to allow buffers to be marked and then deleted.

Currently there's [a bug](https://github.com/d11wtq/ctrlp_bdelete.vim/issues/2) in my plugin that cannot be fixed on my side alone, since it requires "resetting" or "emptying" ctrlp's internal `s:marked` dictionary.

This simply defines a function that can be called to clear the marked list.

If you know another way I can achieve this without adding such a function to ctrlp, I'd be happy to do that instead.
