### PR TITLE
Check shell in Windows before assuming cmd.exe

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -387,7 +387,7 @@ fu! s:UserCmd(lscmd)
 	if exists('+ssl') && &ssl
 		let [ssl, &ssl, path] = [&ssl, 0, tr(path, '/', '\')]
 	en
-	if has('win32') || has('win64')
+	if (has('win32') || has('win64')) && match(&shellcmdflag, "/") != -1
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path


### PR DESCRIPTION
In Windows, some users set the Cygwin shell as their Vim shell, consider
this before rewriting `cd` calls. Checking if `shellcmdflag` contains a
backslash should catch all true windows shells.

Without this fix, user list commands are broken with a cygwin shell.