### PR TITLE
Scala types for buffertag

### DIFF
--- a/autoload/ctrlp/buffertag.vim
+++ b/autoload/ctrlp/buffertag.vim
@@ -69,6 +69,7 @@ let s:types = {
 	\ 'python' : '%spython%spython%scmf',
 	\ 'rexx'   : '%srexx%srexx%ss',
 	\ 'ruby'   : '%sruby%sruby%scfFm',
+	\ 'scala'  : '%sscala%sscala%sctTmlp',
 	\ 'scheme' : '%sscheme%sscheme%ssf',
 	\ 'sh'     : '%ssh%ssh%sf',
 	\ 'csh'    : '%ssh%ssh%sf',


### PR DESCRIPTION
Not sure if you'll include types for languages that aren't officially supported by Exuberant Ctags, but thought I'd send the PR and let you tell me yes or no.

If not, for anyone landing here by search in the future, here's how to get it to work via `~/.vimrc` instead of built into ctrlp:

```vim
let g:ctrlp_buftag_types.scala = '--language-force=scala --scala-types=ctTmlp'
```

Works with this ctags definition for Scala: https://github.com/majutsushi/tagbar/wiki#scala