### PR TITLE
Remove BufAdd hook for mrufiles.vim:record()

### DIFF
--- a/autoload/ctrlp/mrufiles.vim
+++ b/autoload/ctrlp/mrufiles.vim
@@ -143,7 +143,7 @@ fu! ctrlp#mrufiles#init()
 	let s:locked = 0
 	aug CtrlPMRUF
 		au!
-		au BufAdd,BufEnter,BufLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
+		au BufEnter,BufLeave,BufWritePost * cal s:record(expand('<abuf>', 1))
 		au QuickFixCmdPre  *vimgrep* let s:locked = 1
 		au QuickFixCmdPost *vimgrep* let s:locked = 0
 		au VimLeavePre * cal s:savetofile(s:mergelists())


### PR DESCRIPTION
&buffertype is define after BufAdd event. Hooking record() onto BufAdd
will make getbufvar(..., '&bt') return empty string even for a help
buffer.