### PR TITLE
Use match window opts to set initial window height

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -270,7 +270,7 @@ fu! s:Open()
 	cal s:log(1)
 	cal s:getenv()
 	cal s:execextvar('enter')
-	sil! exe 'keepa' ( s:mw_pos == 'top' ? 'to' : 'bo' ) '1new ControlP'
+	sil! exe 'keepa' ( s:mw_pos == 'top' ? 'to' : 'bo' ) (s:mw_min) 'new ControlP'
 	cal s:buffunc(1)
 	let [s:bufnr, s:winw] = [bufnr('%'), winwidth(0)]
 	let [s:focus, s:prompt] = [1, ['', '', '']]


### PR DESCRIPTION
Use the min height of the match window as the initial height of the
ControlP window, rather than always using 1 as the starting height.

This is primarily to workaround MacVim rendering glitches triggered by
automagic resizing of windows when in non-native fullscreen mode, and
core text renderer is enabled, but doesn't seem an unreasonable default.

When MacVim is running in non-native fullscreen mode with core text
renderer enabled, automatically resizing windows causes some parts of
the screen to become blacked out. This is a known issue with MacVim...
http://vim.1045645.n5.nabble.com/Trouble-with-the-Core-Text-renderer-in-non-native-full-screen-td5713348.html

Allowing the ControlP window to open with a fixed height, by setting the
min and max match window height to the same value, makes it trivial to
work around the rendering glitches using the g:ctrlp_buffer_func option
to clear and redraw the screen when exiting the ControlP buffer, e.g.

    " Clear and redraw screen when exiting CtrlP buffer
    let g:ctrlp_buffer_func = {
      \ 'exit':  'RedrawScreen',
      \ }
    function RedrawScreen()
      exec 'redraw!'
    endfunction

Before this change, the only solution I could find to the need to redraw
after the ControlP window was resized to match window min height was a
fugly CursorMoved autocmd to redraw the screen the first time the cursor
moves inside the ControlP window, e.g.

    " Fix the dimensions of the CtrlP window to avoid dynamic resizing
    let g:ctrlp_match_window = 'bottom,order:btt,min:10,max:10,results:10'

    " Redraw screen when CtrlP window is resized after scanning for files
    " This is only necessary because CtrlP doesn't open the window using
    " the dimensions set above, but resizes *after* scanning for files.
    autocmd CursorMoved ControlP
      \ if !exists('b:ctrlp_did_redraw') |
      \   exec 'redraw!' |
      \   let b:ctrlp_did_redraw = 1 |
      \ endif

This commit allows me to remove that fugly CursorMoved autocmd, which
makes me super happy :-)