### PR TITLE
Allow ctrlp_user_command to not have '%s' in it

### DIFF
--- a/autoload/ctrlp.vim
+++ b/autoload/ctrlp.vim
@@ -391,7 +391,12 @@ fu! s:UserCmd(lscmd)
 		let lscmd = substitute(lscmd, '\v(^|\&\&\s*)\zscd (/d)@!', 'cd /d ', '')
 	en
 	let path = exists('*shellescape') ? shellescape(path) : path
-	let g:ctrlp_allfiles = split(system(printf(lscmd, path)), "\n")
+	if lscmd =~ "%s"
+		let [full_lscmd] = [printf(lscmd, path)]
+	else
+		let [full_lscmd] = [lscmd]
+	en
+	let g:ctrlp_allfiles = split(system(full_lscmd), "\n")
 	if exists('+ssl') && exists('ssl')
 		let &ssl = ssl
 		cal map(g:ctrlp_allfiles, 'tr(v:val, "\\", "/")')


### PR DESCRIPTION
Previously, this command _always_ executed: `printf(lscmd, path)`, and
lscmd is set to the value of ctrlp_user_command if that value is set.
The problem is that if ctrlp_user_command does not have a %s in it, then
printf command receives, as its first parameter, a string that doesn't
have %s in it. However, it also receives a second parameter. This causes
printf to throw an error saying that there are too many parameters. That
error is silently caught (line 351). The net result is that the users
experiences the symptom of seeing the message "NO ENTRIES" every time.