### PR TITLE
fix url in readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,4 +88,4 @@ Use your favorite method or check the homepage for a [quick installation guide][
 
 [1]: http://i.imgur.com/yIynr.png
 [2]: https://github.com/kien/ctrlp.vim/tree/extensions
-[3]: http://kien.github.com/ctrlp.vim#installation
+[3]: http://kien.github.io/ctrlp.vim#installation


### PR DESCRIPTION
In this I fixed the url of installation guide from kien.github.com to kien.github.io.
Please make the same change in Repository About section as well.